### PR TITLE
Load resources over HTTPS to prevent warnings

### DIFF
--- a/css/main.scss
+++ b/css/main.scss
@@ -8,7 +8,7 @@ $baseurl: '{{ site.baseurl }}/images';
 @import 'libs/functions';
 @import 'libs/mixins';
 @import 'font-awesome.min.css';
-@import url('http://fonts.googleapis.com/css?family=Open+Sans:400,400italic,600,600italic,800,800italic');
+@import url('https://fonts.googleapis.com/css?family=Open+Sans:400,400italic,600,600italic,800,800italic');
 
 /*
 	Spectral by HTML5 UP


### PR DESCRIPTION
Shouldn't be trying to load HTTP resources if the site is being served over HTTPS. Just fixes the url for the Google web fonts.